### PR TITLE
private-shortcode-visible-all-users

### DIFF
--- a/includes/class-mas-static-content-shortcodes.php
+++ b/includes/class-mas-static-content-shortcodes.php
@@ -50,6 +50,11 @@ class Mas_Static_Content_Shortcodes {
 		$original_post       = $GLOBALS['post'];
 		$content             = '';
 		$static_content_post = get_post( $atts['id'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		if ( 'private' === get_post_status( $static_content_post ) && ! current_user_can( 'read_private_posts' ) ) {
+			return '';
+		}
+
 		$GLOBALS['post']     = $static_content_post;
 
 		setup_postdata( $static_content_post );


### PR DESCRIPTION
1. At The Admin menu you can see the "Static Contents" option, like on it.
2. On the new page you can add a new page for "Static Contents" and after adding the page and saving the data at the "Static Contents" main page you can see the "Shortcode" is generated.
3. by hovering on the page box you can see the " Quick Edit" option, now make the page "Private" and click on "Update".
4. Now we expect that content to be Private and other users can not access the data inside the page.
5. Now by the lowest user role who has access to add the post, "Contributor" we make a post, and in the setting page of the post we add the shortcut code like: [mas_static_content id="FUZZ"] and then we can read the data in all file especially the Privates one.
